### PR TITLE
Git page allure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,9 @@ jobs:
           allure_history: allure-history
           subfolder: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'main' }}
 
-      - name: Fix permissions
-        run: sudo chmod -R 777 allure-history
+      - name: Fix ownership
+        if: always()
+        run: sudo chown -R $USER:$USER allure-history
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq


### PR DESCRIPTION
This pull request makes several improvements to the GitHub Actions CI workflow, focusing on better caching, enhanced Allure reporting, and improved test failure handling. The changes aim to optimize workflow performance, provide more informative feedback on test results, and generate a clear dashboard for test reports.

**CI workflow improvements:**

- Added pip package caching to both lint and test jobs to speed up dependency installation. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR29-R46) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR59-R98)
- Added caching for Allure report history and results to preserve test report data across workflow runs.

**Allure reporting enhancements:**

- Upgraded the Allure report action to a specific version (`v1.4.0`) and improved how Allure history is retrieved from `gh-pages`.
- Added a step to generate a DevOps Allure Dashboard (`index.html`) summarizing the latest 20 PR and main branch test reports, including statistics and flaky test rates.

**Test failure handling and workflow robustness:**

- Introduced a step to automatically fail pull requests if any tests are failed or broken, using Allure summary data and `jq` for JSON parsing.
- Added steps to fix permissions for Allure history files and install `jq` for JSON processing in the workflow.

**Other workflow adjustments:**

- Refined the workflow trigger conditions to ensure jobs only run on pushes or when a pull request is not a draft. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-R17) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR29-R46)
- Renamed the test job from `pytest` to `pytest-and-report` for clarity.

## Link to Allure results for this PR (required)
Provide a URL to the Allure report or CI artifact that contains the test results for this PR. Examples:
- Allure server: https://ua-5307-taqc.github.io/greencity5307/pr-106
- CI artifact: https://github.com/UA-5307-TAQC/greencity5307/actions?query=branch%3Agit_page_allure

If CI produces `allure-results` as an artifact, include a direct link to the artifact or to the published Allure report.

## Type of change
- [ ] CI / pipeline change

## Reviewer checklist
- [ ] CI is green or there is an explained reason for failures

## Files changed (high level)
- `.github/workflows/ci.yml` - updated 
