### PR TITLE
Add UI test for filters and search controls on Saved Places page (TC-…

### DIFF
--- a/pages/abstract_pages/saved_abstract/places_saved_page.py
+++ b/pages/abstract_pages/saved_abstract/places_saved_page.py
@@ -37,7 +37,7 @@ class PlacesSavedPage(SavedAbstract):
     saved_places_chip_locator: Locators = (
         By.XPATH,
         "//button[.//span[contains(., 'Saved Places') "
-        "or contains(., 'Збереженні місця')]]"
+        "or contains(., 'Saved places') or contains(., 'Збережені місця')]]"
     )
 # -----------------------------
     shops_filter_locator: Locators = (

--- a/tests/ui/places_saved_page_tests/test_filters_and_search_on_saved_places_page.py
+++ b/tests/ui/places_saved_page_tests/test_filters_and_search_on_saved_places_page.py
@@ -15,7 +15,6 @@ from pages.common_pages.main_page import MainPage
 def test_filters_and_search_controls_on_saved_places_page(driver: WebDriver):
     """Test visibility of filters and search controls on Saved Places page."""
     with allure.step("Open GreenCity main page"):
-        driver.get(Config.BASE_UI_URL)
         main_page = MainPage(driver)
         assert main_page.is_page_opened()
 


### PR DESCRIPTION
…PS-03)

# Pull Request

## Summary
- What: Added UI test to verify filters and search controls on the Saved Places page.
- Why: To ensure that search inputs, filter buttons, and the map section are displayed correctly on the Saved Places page.

## Link to issue / task (required)
Provide a direct link to the issue or task this branch addresses. Example:
- Issue / Task / TestCase: https://github.com/UA-5307-TAQC/greencity5307/issues/180#issue-4032713034

Note: PRs without a valid issue/task/testcase link may be closed without review.

## Link to Allure results for this PR (required)
Provide a URL to the Allure report or CI artifact that contains the test results for this PR. Examples:
- Allure server: https://ua-5307-taqc.github.io/greencity5307/pr-{pr-id}
- CI artifact: https://github.com/UA-5307-TAQC/greencity5307/actions?query=branch%3A{branch-name}

If CI produces `allure-results` as an artifact, include a direct link to the artifact or to the published Allure report.

## Type of change
- [ ] Bug fix
- [x] New test(s)
- [ ] Test refactor / cleanup
- [ ] CI / pipeline change
- [ ] Documentation
- [ ] Other: ________

## Environment & Configuration
- Browser: Chrome

## How to run tests locally (PowerShell)
1. Create and activate a virtual environment
```powershell
python -m venv .venv
.\.venv\Scripts\Activate.ps1
```
2. Install dependencies
```powershell
pip install -r requirements.txt
```
3. Run the full test suite
```powershell
pytest -q
```
4. Run a single test
```powershell
pytest tests/path/to/test_module.py::test_name -q
```
5. Generate Allure results locally
```powershell
allure serve allure-results
```
6. Example of selecting browser via environment variable
```powershell
$env:BROWSER = 'chrome'; pytest -q
# or for Firefox
$env:BROWSER = 'firefox'; pytest -q
```

## Notes for reviewers
- Test intent: does the test verify the intended behavior?
- Reliability: are waits, locators, and assertions robust (minimize flakiness)?
- CI: did the pipeline run, and are Allure results available?
- Security: no secrets, tokens, or credentials are included in the PR.

## Author checklist (before requesting review)
- [x] I added a link to the issue/task/testcase (required)
- [x] I added a link to the Allure results for this PR (required)
- [x] I ran tests locally: `pytest -q`
- [x] I ran linting: `pylint .` (or the project's configured linter)
- [ ] I updated documentation if needed (tests, configs, or setup)
- [x] No secrets or credentials are included in this PR
- [x] If browser tests were added, I listed which browsers to run on

## Reviewer checklist
- [x] Issue/task/testcase matches the changes in the PR
- [x] Allure results are present and show passed/failed tests
- [x] Tests are meaningful and do not duplicate existing coverage
- [x] CI is green or there is an explained reason for failures

## Files changed (high level)
- `tests/ui/places_saved_page_tests/test_filters_and_search_on_saved_places_page.py` – added test TC-PS-03
- `pages/abstract_pages/saved_abstract/places_saved_page.py` – added locators and methods for filters, search inputs, and map section